### PR TITLE
Bump pyenv to v1.2.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-    "_from": "pyenv@^1.2.18",
-    "_id": "zsh-pyenv@1.2.18",
+    "_from": "pyenv@^1.2.20",
+    "_id": "zsh-pyenv@1.2.20",
     "_inBundle": false,
     "_location": "/zsh-pyenv",
     "_phantomChildren": {},
     "_requested": {
         "type": "range",
         "registry": true,
-        "raw": "pyenv@^1.2.18",
+        "raw": "pyenv@^1.2.20",
         "name": "pyenv",
         "escapedName": "pyenv",
-        "rawSpec": "^1.2.18",
+        "rawSpec": "^1.2.20",
         "saveSpec": null,
-        "fetchSpec": "^1.2.18"
+        "fetchSpec": "^1.2.20"
     },
     "_requiredBy": [],
-    "_resolved": "https://github.com/pyenv/pyenv/archive/v1.2.18.tar.gz",
-    "_shasum": "b7c5a739eb7c4478e7808f9a722f588493999e92",
-    "_spec": "pyenv@^1.2.18",
+    "_resolved": "https://github.com/pyenv/pyenv/archive/v1.2.20.tar.gz",
+    "_shasum": "c79e390d359ef1bc736e41ba6dd5ca016f5f4842",
+    "_spec": "pyenv@^1.2.20",
     "_where": "/root/github2/pkg-pyenv",
     "author": "Yuu Yamashita, Sam Stephenson, Mislav Marohnić, Josh Friend",
     "bugs": {
@@ -42,12 +42,12 @@
     "scripts": {
         "test": "make test"
     },
-    "version": "1.2.18",
+    "version": "1.2.20",
     "zsh-data": {
         "plugin-info": {
             "user": "pyenv",
             "plugin": "pyenv",
-            "version": "1.2.18",
+            "version": "1.2.20",
             "requires": "bgn;bash"
         },
         "zplugin-ices": {


### PR DESCRIPTION
New version of pyenv (v1.2.20) was release recently: https://github.com/pyenv/pyenv/releases/tag/v1.2.20.
Thank you.
